### PR TITLE
Makefile: Fix bashism error on Debian/Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install:
 	@echo "Installing Rime data to '$(DESTDIR)$(RIME_DATA_DIR)'."
 	@install -d $(DESTDIR)$(RIME_DATA_DIR)
 	@install -m 644 $(OUTPUT)/*.* $(DESTDIR)$(RIME_DATA_DIR)
-	@if [[ -d "$(OUTPUT)/build" ]]; then \
+	@if [ -d "$(OUTPUT)/build" ]; then \
 	  install -d $(DESTDIR)$(RIME_DATA_DIR)/build; \
 	  install -m 644 $(OUTPUT)/build/*.* $(DESTDIR)$(RIME_DATA_DIR)/build; \
 	fi


### PR DESCRIPTION
Hello, I am trying to solve the problem of Rime ecosystem on Debian
when I run into a problem of bashism in `plum/Makefile`.

Shell snippets in Makefile is using `[[ ]]` grammar,
which is a bash extension and is not supported by standard
(POSIX) `/bin/sh`.

This commit would use `[ ]` instead of `[[ ]]` to fix the problem
where `/bin/sh` is not bash, which is typical for all Debian and
Ubuntu derivatives.