### PR TITLE
Add -R to curl call in download_file

### DIFF
--- a/scripts/recipe.sh
+++ b/scripts/recipe.sh
@@ -68,7 +68,7 @@ download_file() {
     (
         cd "${package_dir}"
         echo $(info "$msg") $(highlight "$filename")
-        curl -fL -o "$filename" $check_update "${url#*::}"
+        curl -fRL -o "$filename" $check_update "${url#*::}"
     )
 }
 


### PR DESCRIPTION
Attempt to make local file's mtime follow remote last modified time.
This works better with -z to avoid sticking to an old version without
updating it.