### PR TITLE
Align the `rime_dir` environment variable with $XDG_DATA_HOME of the XDG Base Directory Specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ bash rime-install lotem/rime-forge@master/lotem-packages.conf
 For third-party Rime distributions, specify the `rime_frontend` variable in the command line:
 
 ```sh
-rime_frontend=fcitx-rime bash rime-install
+rime_frontend=fcitx5-rime bash rime-install
 ```
 
 or set `rime_dir` to Rime user directory
 
 ```sh
-rime_dir="$HOME/.config/fcitx/rime" bash rime-install
+rime_dir="$HOME/./local/share/fcitx5/rime" bash rime-install
 ```
 
 To update /plum/ itself, run


### PR DESCRIPTION
The rime-install script has adopted this specification, so the document needs to be updated accordingly. See [here](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for more info about the XDG Base Directory Specification.