### PR TITLE
Follow the symlink to `rime-install` if exists

### DIFF
--- a/rime-install
+++ b/rime-install
@@ -6,7 +6,7 @@ fi
 
 if [[ -z "${plum_dir}" ]]; then
     # am I in a working copy already?
-    plum_dir="$(dirname "$0")"
+    plum_dir="$(dirname "$(readlink -f "$0")")"
     if ! [[ -f "${plum_dir}"/scripts/install-packages.sh ]]; then
         # make a copy of plum in a subdirectory
         plum_dir='plum'


### PR DESCRIPTION
After installing `plum`, we would like to execute `rime-install` from anywhere, instead of switching to the installation directory or the directory of the specified program. The best way to do this is to make a symlink from the actual file to the directory in the user's PATH (e.g. `~/bin`, `~/.local/bin`).
This PR will enable those who have created their own symlinks to use the program directly without reinstalling.