### PR TITLE
fix(recipe): not expanding wildcard in package dir

### DIFF
--- a/scripts/recipe.sh
+++ b/scripts/recipe.sh
@@ -76,10 +76,15 @@ apply_download_files() {
     if ! grep -q '^download_files:' "${recipe_file}"; then
         return
     fi
-    local file_patterns=(
-        $(cat "${recipe_file}" |
-            print_section 'download_files' |
-            sed '/^[ ]*#/ d; s/^[ ]*-[ ]//'
+    recipt_content=$(cat "${recipe_file}")
+    (
+        cd "${package_dir}"
+        local file_patterns=(
+            $(
+                echo "${recipt_content}" |
+                    print_section 'install_files' |
+                    sed '/^[ ]*#/ d; s/^[ ]*-[ ]//'
+            )
         )
     )
     if (( ${#file_patterns[@]} == 0 )); then
@@ -97,10 +102,15 @@ apply_install_files() {
     if ! grep -q '^install_files:' "${recipe_file}"; then
         return
     fi
-    local file_patterns=(
-        $(cat "${recipe_file}" |
-            print_section 'install_files' |
-            sed '/^[ ]*#/ d; s/^[ ]*-[ ]//'
+    recipt_content=$(cat "${recipe_file}")
+    (
+        cd "${package_dir}"
+        local file_patterns=(
+            $(
+                echo "${recipt_content}" |
+                    print_section 'install_files' |
+                    sed '/^[ ]*#/ d; s/^[ ]*-[ ]//'
+            )
         )
     )
     if (( ${#file_patterns[@]} == 0 )); then


### PR DESCRIPTION
Now plum is expanding wildcard in current working directory, but not pkg directory. 
That's why this happened:
```bash
# cwd = ~/AppData/Roaming/Rime/
$ bash rime-install iDvel/rime-ice:others/recipes/full cantonese
Installing for Rime frontend: rime/weasel
Updating package: iDvel/rime-ice
Already up to date.
Installing recipe: iDvel/rime-ice:others/recipes/full
ls: cannot access 'opencc/HKVariantsFull.txt': No such file or directory
ls: cannot access 'opencc/t2hkf.json': No such file or directory
Error: some files to install are not found.
```