### PR TITLE
fix: script raw url was null

### DIFF
--- a/rime-install.bat
+++ b/rime-install.bat
@@ -225,7 +225,7 @@ if exist plum/rime-install (
 ) else (
   echo Downloading rime-install ...
   set script_url=https://raw.githubusercontent.com/rime/plum/master/rime-install
-  curl -fsSL "%script_url%" -o "%download_cache_dir%"/rime-install
+  curl -fsSL "!script_url!" -o "%download_cache_dir%"/rime-install
   if errorlevel 1 (
     set error_message=Error downloading rime-install
     goto error


### PR DESCRIPTION
修复：第一次使用时，rime-install raw 的 URI 为空。

原因：设置了延迟展开，但没有使用 !! 引用设置的变量。

![1709969296](https://github.com/rime/plum/assets/76689045/31374d44-7005-4580-9bc9-86530b3d732c)
