### PR TITLE
fix(WSLENV): properly translate paths in WSLENV environment variable into unix-style path

### DIFF
--- a/rime-install.bat
+++ b/rime-install.bat
@@ -212,7 +212,8 @@ exit /b
 call :install_git /needed
 if errorlevel 1 exit /b %errorlevel%
 
-set WSLENV=plum_dir:rime_dir
+rem use /p flag to properly translate Windows paths to WSL paths
+set WSLENV=plum_dir/p:rime_dir/p
 
 if defined plum_dir if exist "%plum_dir%"/rime-install (
    bash "%plum_dir%"/rime-install %*


### PR DESCRIPTION
use `/p` flag to properly translate Windows paths to WSL paths. 
`WSLENV=plum_path` transfer the `plum_path` var as is into wsl, which is invalid in wsl. 
`WSLENV=plum_path/p` will automatically translate plum_path into unix-style path, like `C:\rime => /mnt/c/rime`.