### PR TITLE
fix(rime-install): Add fallback for readlink -f

### DIFF
--- a/rime-install
+++ b/rime-install
@@ -6,7 +6,7 @@ fi
 
 if [[ -z "${plum_dir}" ]]; then
     # am I in a working copy already?
-    plum_dir="$(dirname "$(readlink -f "$0")")"
+    plum_dir="$(dirname "$(readlink -f "$0" 2> /dev/null || readlink "$0" || echo "$0")")"
     if ! [[ -f "${plum_dir}"/scripts/install-packages.sh ]]; then
         # make a copy of plum in a subdirectory
         plum_dir='plum'


### PR DESCRIPTION
This PR adds fallback for older macOS systems that lack `readlink` option `-f` support (introduced in macOS 12.3).